### PR TITLE
ブラウザタブのタイトルとアイコンを更新

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>学習管理システム</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/vite.svg
+++ b/frontend/public/vite.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--logos" width="31.88" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 256 257"><defs><linearGradient id="IconifyId1813088fe1fbc01fb466" x1="-.828%" x2="57.636%" y1="7.652%" y2="78.411%"><stop offset="0%" stop-color="#41D1FF"></stop><stop offset="100%" stop-color="#BD34FE"></stop></linearGradient><linearGradient id="IconifyId1813088fe1fbc01fb467" x1="43.376%" x2="50.316%" y1="2.242%" y2="89.03%"><stop offset="0%" stop-color="#FFEA83"></stop><stop offset="8.333%" stop-color="#FFDD35"></stop><stop offset="100%" stop-color="#FFA800"></stop></linearGradient></defs><path fill="url(#IconifyId1813088fe1fbc01fb466)" d="M255.153 37.938L134.897 252.976c-2.483 4.44-8.862 4.466-11.382.048L.875 37.958c-2.746-4.814 1.371-10.646 6.827-9.67l120.385 21.517a6.537 6.537 0 0 0 2.322-.004l117.867-21.483c5.438-.991 9.574 4.796 6.877 9.62Z"></path><path fill="url(#IconifyId1813088fe1fbc01fb467)" d="M185.432.063L96.44 17.501a3.268 3.268 0 0 0-2.634 3.014l-5.474 92.456a3.268 3.268 0 0 0 3.997 3.378l24.777-5.718c2.318-.535 4.413 1.507 3.936 3.838l-7.361 36.047c-.495 2.426 1.782 4.5 4.151 3.78l15.304-4.649c2.372-.72 4.652 1.36 4.15 3.788l-11.698 56.621c-.732 3.542 3.979 5.473 5.943 2.437l1.313-2.028l72.516-144.72c1.215-2.423-.88-5.186-3.54-4.672l-25.505 4.922c-2.396.462-4.435-1.77-3.759-4.114l16.646-57.705c.677-2.35-1.37-4.583-3.769-4.113Z"></path></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
+  <defs>
+    <linearGradient id="lmsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3B82F6"></stop>
+      <stop offset="100%" stop-color="#1E40AF"></stop>
+    </linearGradient>
+  </defs>
+  <!-- Book/Learning symbol -->
+  <rect x="6" y="8" width="20" height="16" rx="2" fill="url(#lmsGradient)" stroke="#1E40AF" stroke-width="1"/>
+  <!-- Book pages -->
+  <line x1="9" y1="12" x2="23" y2="12" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="9" y1="15" x2="20" y2="15" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="9" y1="18" x2="18" y2="18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Graduation cap symbol -->
+  <path d="M16 4 L24 7 L16 10 L8 7 Z" fill="#FCD34D" stroke="#F59E0B" stroke-width="0.5"/>
+  <path d="M22 8 L22 12 Q22 13 20 13.5 Q18 14 16 14 Q14 14 12 13.5 Q10 13 10 12 L10 8" fill="none" stroke="#F59E0B" stroke-width="1" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## 概要
学習管理システム（LMS）のブラウザタブのタイトルとアイコンを更新しました。

### 変更内容

#### 1. ブラウザタブタイトルの変更
- **変更前**: `Vite + React + TS`
- **変更後**: `学習管理システム`
- **ファイル**: `frontend/index.html`

#### 2. ブラウザタブアイコンの変更
- **変更前**: Vite のロゴ SVG
- **変更後**: LMS 専用のカスタムアイコン
- **ファイル**: `frontend/public/vite.svg`

### 新しいアイコンのデザイン
- 📚 青いグラデーションの本（学習教材を象徴）
- 📄 白い線で表現されたページ（コンテンツを象徴）
- 🎓 ゴールドの卒業帽（教育・達成を象徴）
- 教育機関にふさわしいプロフェッショナルなデザイン

### 影響範囲
- フロントエンドの UI/UX の向上
- ブランディングの一貫性向上
- ユーザー体験の改善

### テスト状況
- ✅ 開発サーバーの正常動作確認済み
- ✅ ESLint チェック通過
- ✅ TypeScript 型チェック通過

Closes #53
Closes #54