### PR TITLE
fix: レッスン表示修正 - 非登録ユーザーでもpublishedレッスンを表示可能にする

### DIFF
--- a/backend/src/controllers/lessonController.ts
+++ b/backend/src/controllers/lessonController.ts
@@ -22,7 +22,7 @@ export interface LessonUpdateRequest {
 }
 
 export interface LessonQueryRequest {
-  isPublished?: string;
+  isPublished?: boolean;
   search?: string;
   page?: string;
   limit?: string;
@@ -115,7 +115,7 @@ export class LessonController {
 
       const query: LessonQuery = {};
       
-      if (req.query.isPublished !== undefined) query.isPublished = req.query.isPublished === 'true';
+      if (req.query.isPublished !== undefined) query.isPublished = req.query.isPublished;
       if (req.query.search) query.search = req.query.search;
       if (req.query.page) query.page = parseInt(req.query.page, 10);
       if (req.query.limit) query.limit = parseInt(req.query.limit, 10);

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -241,7 +241,11 @@ export const lessonSchemas = {
   }),
 
   query: Joi.object({
-    isPublished: Joi.boolean(),
+    isPublished: Joi.alternatives()
+      .try(
+        Joi.boolean(),
+        Joi.string().valid('true', 'false').custom((value) => value === 'true')
+      ),
     search: Joi.string().trim(),
   }).concat(commonSchemas.pagination),
 

--- a/backend/src/services/__tests__/lessonService.visibility.test.ts
+++ b/backend/src/services/__tests__/lessonService.visibility.test.ts
@@ -1,0 +1,156 @@
+import { LessonService } from '../lessonService';
+import { NotFoundError } from '../../utils/errors';
+
+// Mock the entire module
+jest.mock('@prisma/client', () => {
+  const mockLessonFunctions = {
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const mockCourseFunctions = {
+    findUnique: jest.fn(),
+  };
+
+  const mockUserProgressFunctions = {
+    findFirst: jest.fn(),
+  };
+
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      lesson: mockLessonFunctions,
+      course: mockCourseFunctions,
+      userProgress: mockUserProgressFunctions,
+    })),
+  };
+});
+
+// Get the mocked prisma instance for testing
+const { PrismaClient } = require('@prisma/client');
+const mockPrisma = new PrismaClient();
+const mockLessonFunctions = mockPrisma.lesson;
+const mockCourseFunctions = mockPrisma.course;
+
+describe('LessonService - Visibility Fix', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockCourse = { id: 2, title: 'Advanced React Patterns' };
+  const mockLessons = [
+    {
+      id: 4,
+      courseId: 2,
+      title: 'Compound Components',
+      sortOrder: 1,
+      isPublished: true,
+      course: mockCourse,
+      _count: { learningMaterials: 0, userProgress: 0 },
+    },
+    {
+      id: 5,
+      courseId: 2,
+      title: 'Render Props Pattern',
+      sortOrder: 2,
+      isPublished: true,
+      course: mockCourse,
+      _count: { learningMaterials: 0, userProgress: 0 },
+    },
+  ];
+
+  describe('getLessonsByCourse - Visibility Fix', () => {
+    it('should allow anonymous users to see published lessons (GitHub Issue #140 fix)', async () => {
+      mockCourseFunctions.findUnique.mockResolvedValue(mockCourse);
+      mockLessonFunctions.count.mockResolvedValue(2);
+      mockLessonFunctions.findMany.mockResolvedValue(mockLessons);
+
+      // Anonymous user (no userId, no userRole)
+      const result = await LessonService.getLessonsByCourse(2, { page: 1, limit: 10 });
+
+      expect(result).toEqual({
+        lessons: mockLessons,
+        total: 2,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
+
+      // Verify that the query only shows published lessons
+      expect(mockLessonFunctions.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            courseId: 2,
+            isPublished: true,
+          }),
+        })
+      );
+    });
+
+    it('should allow non-enrolled users to see published lessons (GitHub Issue #140 fix)', async () => {
+      mockCourseFunctions.findUnique.mockResolvedValue(mockCourse);
+      mockLessonFunctions.count.mockResolvedValue(2);
+      mockLessonFunctions.findMany.mockResolvedValue(mockLessons);
+
+      // Non-enrolled user with USER role
+      const result = await LessonService.getLessonsByCourse(2, { page: 1, limit: 10 }, 123, 'USER');
+
+      expect(result).toEqual({
+        lessons: mockLessons,
+        total: 2,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
+
+      // Verify that the query only shows published lessons
+      expect(mockLessonFunctions.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            courseId: 2,
+            isPublished: true,
+          }),
+        })
+      );
+    });
+
+    it('should allow admin users to see all lessons including unpublished', async () => {
+      mockCourseFunctions.findUnique.mockResolvedValue(mockCourse);
+      mockLessonFunctions.count.mockResolvedValue(2);
+      mockLessonFunctions.findMany.mockResolvedValue(mockLessons);
+
+      // Admin user
+      const result = await LessonService.getLessonsByCourse(2, { page: 1, limit: 10 }, 456, 'ADMIN');
+
+      expect(result).toEqual({
+        lessons: mockLessons,
+        total: 2,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
+
+      // Verify that admin can see all lessons (no isPublished filter)
+      expect(mockLessonFunctions.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            courseId: 2,
+            // Should not have isPublished filter for admin
+          }),
+        })
+      );
+      
+      // Ensure isPublished filter is NOT applied for admin
+      const whereClause = mockLessonFunctions.findMany.mock.calls[0][0].where;
+      expect(whereClause.isPublished).toBeUndefined();
+    });
+
+    it('should throw NotFoundError if course does not exist', async () => {
+      mockCourseFunctions.findUnique.mockResolvedValue(null);
+
+      await expect(LessonService.getLessonsByCourse(999, {})).rejects.toThrow(
+        new NotFoundError('Course not found')
+      );
+    });
+  });
+});

--- a/backend/src/services/lessonService.ts
+++ b/backend/src/services/lessonService.ts
@@ -250,19 +250,10 @@ export class LessonService {
       if (userRole === 'ADMIN') {
         // Admins can see all lessons (published and unpublished)
         showUnpublished = true;
-      } else if (userId) {
-        // Check if user is enrolled in the course
-        const isEnrolled = await this.isUserEnrolledInCourse(userId, courseId);
-        if (isEnrolled) {
-          // Enrolled users can see published lessons
-          showUnpublished = false;
-        } else {
-          // Non-enrolled users can't see any lessons - use impossible condition
-          whereClause.id = -1; // This will return no results
-        }
       } else {
-        // No user context - no lessons visible - use impossible condition
-        whereClause.id = -1; // This will return no results
+        // Non-admin users (including non-enrolled and anonymous users) can see published lessons
+        // This allows course browsing and preview functionality
+        showUnpublished = false;
       }
 
       // Apply isPublished filter unless user is admin


### PR DESCRIPTION
## 概要
コース詳細ページでレッスンが表示されない問題を修正しました。非登録ユーザーでも公開されたレッスンを見ることができるようになります。

## 修正内容
- **バックエンドAPIのクエリパラメータ検証修正**: `isPublished` パラメータが正しく処理されない問題を解決
- **型定義の修正**: `LessonQueryRequest` インターフェースで `isPublished` の型を `boolean` に変更
- **バリデーション修正**: `validation.ts` で文字列 "true"/"false" を適切にブール値に変換するよう修正
- **可視性ルールの修正**: `lessonService.ts` で非登録ユーザーも公開済みレッスンを閲覧可能にするよう修正

## テスト計画
- [x] コース詳細ページでレッスンが表示されることを確認
- [x] 非登録ユーザーが公開済みレッスンを見られることを確認
- [x] 管理者ユーザーが未公開レッスンも見られることを確認
- [x] API エンドポイントが正しく機能することを確認

Closes #140

🤖 Generated with [Claude Code](https://claude.ai/code)