### PR TITLE
fix: 学習教材作成失敗の問題を修正

### DIFF
--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -266,7 +266,7 @@ export const learningMaterialSchemas = {
     externalUrl: Joi.when('materialType', {
       is: 'URL',
       then: Joi.string().uri().max(1000).required(),
-      otherwise: Joi.forbidden()
+      otherwise: Joi.string().optional().allow('', null)
     }),
     durationMinutes: Joi.number().integer().min(1).optional(),
     allowManualProgress: Joi.when('materialType', {
@@ -277,20 +277,20 @@ export const learningMaterialSchemas = {
     sortOrder: Joi.number().integer().min(1).optional(),
     isPublished: Joi.boolean().default(false),
     // File fields are populated by upload middleware
-    filePath: Joi.string().when('materialType', {
+    filePath: Joi.when('materialType', {
       is: 'FILE',
-      then: Joi.required(),
-      otherwise: Joi.forbidden()
+      then: Joi.string().required(),
+      otherwise: Joi.string().optional().allow('', null)
     }),
-    fileSize: Joi.number().integer().min(1).when('materialType', {
+    fileSize: Joi.when('materialType', {
       is: 'FILE',
-      then: Joi.required(),
-      otherwise: Joi.forbidden()
+      then: Joi.number().integer().min(1).required(),
+      otherwise: Joi.number().optional().allow(null)
     }),
-    fileType: Joi.string().when('materialType', {
+    fileType: Joi.when('materialType', {
       is: 'FILE',
-      then: Joi.required(),
-      otherwise: Joi.forbidden()
+      then: Joi.string().required(),
+      otherwise: Joi.string().optional().allow('', null)
     }),
   }),
 

--- a/frontend/src/components/materials/admin/MaterialForm.tsx
+++ b/frontend/src/components/materials/admin/MaterialForm.tsx
@@ -169,10 +169,17 @@ export function MaterialForm({
         // For create mode, handle file upload separately
         const createData = { ...formData };
         
-        // Remove empty optional fields
+        // Remove empty optional fields and fields not relevant to material type
         if (!createData.description?.trim()) delete createData.description;
         if (createData.materialType !== 'URL') delete createData.externalUrl;
         if (createData.durationMinutes === undefined) delete createData.durationMinutes;
+        
+        // Ensure file-related fields are not sent for non-FILE types
+        if (createData.materialType !== 'FILE') {
+          delete (createData as any).filePath;
+          delete (createData as any).fileSize;
+          delete (createData as any).fileType;
+        }
         
         await onSubmit(createData, selectedFile || undefined);
       }


### PR DESCRIPTION
## 概要
学習教材の作成時に「教材の作成に失敗しました」エラーが発生する問題を修正しました。
特にURLタイプの教材作成で courses/4/lessons/9/edit において発生していた問題です。

## 修正内容

### 1. バックエンドのバリデーション修正
- `backend/src/middleware/validation.ts` の `learningMaterialSchemas.create` を修正
- file関連フィールド（`filePath`, `fileSize`, `fileType`）の検証ルールを `Joi.forbidden()` から `Joi.optional().allow('', null)` に変更
- `externalUrl` フィールドも同様に修正し、URLタイプ以外でも空値を許可

### 2. フロントエンドのデータクリーンアップ改善  
- `frontend/src/components/materials/admin/MaterialForm.tsx` を修正
- URLタイプの教材作成時にfile関連フィールドを明示的に削除する処理を追加
- データ送信前の不要フィールドクリーンアップ処理を改善

### 3. データベースシーケンス修正（運用時対応）
- `learning_materials_id_seq` のシーケンス値が実際のデータと不整合を起こしていた問題を解決
- シーケンス値を正しい値（最大ID+1）にリセット

## 根本原因
1. **バリデーション問題**: Joi.forbidden()により、フロントエンドから空文字列やundefined値が送信された際にバリデーションエラーが発生
2. **シーケンス不整合**: データベースのauto-incrementシーケンスが実際のデータより小さい値になっており、一意制約違反が発生

## テスト確認項目
- ✅ URLタイプの学習教材作成
- ✅ FILEタイプの学習教材作成（既存機能の維持）
- ✅ MANUAL_PROGRESSタイプの学習教材作成（既存機能の維持）
- ✅ バリデーションエラーの適切な処理
- ✅ データベースシーケンスの正常動作

## 影響範囲
- 学習教材作成機能の安定性向上
- 既存の教材作成機能への影響なし
- データベースの整合性確保

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/code)